### PR TITLE
:sparkles: feat(2.0.1): support message type for Markdown

### DIFF
--- a/qywx-spring-boot-model/src/main/java/com/github/shuaidd/dto/MsgMarkdown.java
+++ b/qywx-spring-boot-model/src/main/java/com/github/shuaidd/dto/MsgMarkdown.java
@@ -2,12 +2,16 @@ package com.github.shuaidd.dto;
 
 /**
  * 描述
- *
+ * <p>
  * author ddshuai
  * date 2019-04-08 17:57
  **/
 public class MsgMarkdown {
     private String content;
+
+    public MsgMarkdown(String content) {
+        this.content = content;
+    }
 
     public String getContent() {
         return content;

--- a/qywx-spring-boot-model/src/main/java/com/github/shuaidd/resquest/SendAppChatRequest.java
+++ b/qywx-spring-boot-model/src/main/java/com/github/shuaidd/resquest/SendAppChatRequest.java
@@ -39,6 +39,8 @@ public class SendAppChatRequest {
 
     private MsgMpNews mpnews;
 
+    private MsgMarkdown markdown;
+
     @JsonProperty("miniprogram_notice")
     private MsgMiniprogramNotice miniprogramnotice;
 
@@ -130,6 +132,14 @@ public class SendAppChatRequest {
         this.mpnews = mpnews;
     }
 
+    public MsgMarkdown getMarkdown() {
+        return markdown;
+    }
+
+    public void setMarkdown(MsgMarkdown markdown) {
+        this.markdown = markdown;
+    }
+
     public MsgMiniprogramNotice getMiniprogramnotice() {
         return miniprogramnotice;
     }
@@ -152,6 +162,7 @@ public class SendAppChatRequest {
                 .add("textcard=" + textcard)
                 .add("news=" + news)
                 .add("mpnews=" + mpnews)
+                .add("markdown=" + markdown)
                 .add("miniprogramnotice=" + miniprogramnotice)
                 .toString();
     }

--- a/qywx-spring-boot-model/src/main/java/com/github/shuaidd/resquest/SendMessageRequest.java
+++ b/qywx-spring-boot-model/src/main/java/com/github/shuaidd/resquest/SendMessageRequest.java
@@ -43,6 +43,8 @@ public class SendMessageRequest {
 
     private MsgMpNews mpnews;
 
+    private MsgMarkdown markdown;
+
     @JsonProperty("miniprogram_notice")
     private MsgMiniprogramNotice miniprogramnotice;
 
@@ -150,6 +152,14 @@ public class SendMessageRequest {
 
     public void setMpnews(MsgMpNews mpnews) {
         this.mpnews = mpnews;
+    }
+
+    public MsgMarkdown getMarkdown() {
+        return markdown;
+    }
+
+    public void setMarkdown(MsgMarkdown markdown) {
+        this.markdown = markdown;
     }
 
     public MsgMiniprogramNotice getMiniprogramnotice() {


### PR DESCRIPTION
支持企业微信的Markdown格式。